### PR TITLE
feat(feedfilter): hide floating event badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Or try a prebuilt APK (at your own risk): [hxreborn/Morphe-AutoBuilds](https://g
 
 Everything from [icysymmetra's upstream](https://github.com/icysymmetra/tiktok-patches-for-morphe), plus:
 
-- Disable AI-generated posts ([`FeedFilterPatch.kt`](patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt))
-- Disable telemetry, ByteDance/AppsFlyer/Firebase ([`DisableTelemetryPatch.kt`](patches/src/main/kotlin/app/morphe/patches/tiktok/misc/telemetry/DisableTelemetryPatch.kt))
-- Hide the in-feed playlist bar ([`FeedFilterPatch.kt`](patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt))
-- Separate image and video download folders ([`DownloadsPatch.kt`](patches/src/main/kotlin/app/morphe/patches/tiktok/interaction/downloads/DownloadsPatch.kt))
+- Disable AI-generated posts
+- Disable telemetry, ByteDance/AppsFlyer/Firebase
+- Hide the in-feed playlist bar
+- Hide the floating promotional event badge, e.g. FIFA World Cup
+- Separate image and video download folders
 
 <br>
 

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/EventBadgeFilter.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/EventBadgeFilter.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2026 hxreborn
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+package app.morphe.extension.tiktok.feedfilter;
+
+import app.morphe.extension.tiktok.settings.Settings;
+
+public final class EventBadgeFilter {
+    private EventBadgeFilter() {}
+
+    public static boolean shouldHide() {
+        return Settings.HIDE_EVENT_BADGE.get();
+    }
+}

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
@@ -24,6 +24,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting HIDE_STORY = new BooleanSetting("hide_story", FALSE, true);
     public static final BooleanSetting HIDE_IMAGE = new BooleanSetting("hide_image", FALSE, true);
     public static final BooleanSetting HIDE_PLAYLIST_BAR = new BooleanSetting("hide_playlist_bar", FALSE, true);
+    public static final BooleanSetting HIDE_EVENT_BADGE = new BooleanSetting("hide_event_badge", FALSE, true);
     public static final BooleanSetting HIDE_AI_GENERATED = new BooleanSetting("hide_ai_generated", FALSE, true);
     public static final StringSetting MIN_MAX_VIEWS = new StringSetting("min_max_views", "0-" + Long.MAX_VALUE, true);
     public static final StringSetting MIN_MAX_LIKES = new StringSetting("min_max_likes", "0-" + Long.MAX_VALUE, true);

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/FeedFilterPreferenceCategory.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/FeedFilterPreferenceCategory.java
@@ -59,6 +59,11 @@ public class FeedFilterPreferenceCategory extends ConditionalPreferenceCategory 
         ));
         addPreference(new TogglePreference(
                 context,
+                "Hide event badge", "Hide the floating promotional event badge shown over the feed.",
+                Settings.HIDE_EVENT_BADGE
+        ));
+        addPreference(new TogglePreference(
+                context,
                 "Hide AI-generated content", "Hide posts labeled as AI-generated from feed.",
                 Settings.HIDE_AI_GENERATED
         ));

--- a/patches-list.json
+++ b/patches-list.json
@@ -224,7 +224,7 @@
     },
     {
       "name": "Feed filter",
-      "description": "Removes ads, livestreams, stories, image videos, the playlist bar below videos, AI-generated posts and videos with a specific amount of views or likes from the feed. (Supports TikTok 43.8.3.)",
+      "description": "Removes ads, livestreams, stories, image videos, the playlist bar below videos, the floating promotional event badge, AI-generated posts and videos with a specific amount of views or likes from the feed. (Supports TikTok 43.8.3.)",
       "use": true,
       "dependencies": [
         "BytecodePatch"

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt
@@ -17,11 +17,12 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 private const val EXTENSION_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/FeedItemsFilter;"
 private const val TAKO_AI_FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/TakoAiFilter;"
 private const val PLAYLIST_BAR_FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/PlaylistBarFilter;"
+private const val EVENT_BADGE_FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/EventBadgeFilter;"
 
 @Suppress("unused")
 val feedFilterPatch = bytecodePatch(
     name = "Feed filter",
-    description = "Removes ads, livestreams, stories, image videos, the playlist bar below videos, AI-generated posts and videos with a specific amount of views or likes from the feed. (Supports TikTok 43.8.3.)",
+    description = "Removes ads, livestreams, stories, image videos, the playlist bar below videos, the floating promotional event badge, AI-generated posts and videos with a specific amount of views or likes from the feed. (Supports TikTok 43.8.3.)",
     default = true,
 ) {
     dependsOn(
@@ -104,6 +105,19 @@ val feedFilterPatch = bytecodePatch(
                 const/4 v0, 0x0
                 return v0
                 :morphe_show_playlist_bar
+                nop
+            """,
+        )
+
+        // Skip attaching the promotional event badge to the feed
+        SpecActTouchpointAttachFingerprint.methodOrNull?.addInstructions(
+            0,
+            """
+                invoke-static {}, $EVENT_BADGE_FILTER_CLASS_DESCRIPTOR->shouldHide()Z
+                move-result v0
+                if-eqz v0, :morphe_attach_event_badge
+                return-void
+                :morphe_attach_event_badge
                 nop
             """,
         )

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/Fingerprints.kt
@@ -31,6 +31,12 @@ internal object PlaylistBottomBarAvailableFingerprint : Fingerprint(
     parameters = listOf("Lcom/ss/android/ugc/aweme/feed/model/VideoItemParams;"),
 )
 
+internal object SpecActTouchpointAttachFingerprint : Fingerprint(
+    definingClass = "/specact/SpecActServiceImpl;",
+    returnType = "V",
+    parameters = listOf("Landroid/view/ViewGroup;", "Landroidx/fragment/app/Fragment;"),
+)
+
 internal object TakoAiFeedButtonSetVisibleFingerprint : Fingerprint(
     definingClass = "/feed/assem/tikbot/TakoAssem;",
     name = "rn",


### PR DESCRIPTION
No-ops the specact touchpoint attach so the promotional event badge (FIFA World Cup pendant) never shows on the feed. Toggle off by default.

Tested: 43.8.3 full bundle, clean install on Pixel 9 Pro, toggle on = badge gone.