### PR TITLE
feat(telemetry): make disabling analytics optional

### DIFF
--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/Settings.java
@@ -82,6 +82,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting CLEAR_DISPLAY = new BooleanSetting("clear_display", FALSE);
     public static final BooleanSetting COPY_COMMENTS_WITHOUT_USERNAME = new BooleanSetting("copy_comments_without_username", TRUE);
     public static final FloatSetting REMEMBERED_SPEED = new FloatSetting("REMEMBERED_SPEED", 1.0f);
+    public static final BooleanSetting DISABLE_ANALYTICS = new BooleanSetting("disable_analytics", FALSE, true);
     public static final BooleanSetting SIM_SPOOF = new BooleanSetting("simspoof", FALSE, true);
     public static final StringSetting SIM_SPOOF_ISO = new StringSetting("simspoof_iso", "us");
     public static final StringSetting SIMSPOOF_MCCMNC = new StringSetting("simspoof_mccmnc", "310260");

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/SettingsStatus.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/SettingsStatus.java
@@ -11,6 +11,7 @@ public class SettingsStatus {
     public static boolean commentTranslationEnabled = false;
     public static boolean downloadEnabled = false;
     public static boolean simSpoofEnabled = false;
+    public static boolean disableTelemetryEnabled = false;
 
     public static void enableFeedFilter() {
         feedFilterEnabled = true;
@@ -30,6 +31,10 @@ public class SettingsStatus {
 
     public static void enableSimSpoof() {
         simSpoofEnabled = true;
+    }
+
+    public static void enableDisableTelemetry() {
+        disableTelemetryEnabled = true;
     }
 
     public static void load() {

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ExtensionPreferenceCategory.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/settings/preference/categories/ExtensionPreferenceCategory.java
@@ -10,6 +10,7 @@ import android.preference.PreferenceScreen;
 
 import app.morphe.extension.shared.settings.BaseSettings;
 import app.morphe.extension.tiktok.settings.Settings;
+import app.morphe.extension.tiktok.settings.SettingsStatus;
 import app.morphe.extension.tiktok.settings.preference.TogglePreference;
 
 @SuppressWarnings("deprecation")
@@ -40,6 +41,14 @@ public class ExtensionPreferenceCategory extends ConditionalPreferenceCategory {
                 Settings.SHOW_SEEKBAR
         ));
 
+        if (SettingsStatus.disableTelemetryEnabled) {
+            addPreference(new TogglePreference(
+                    context,
+                    "Disable analytics",
+                    "Stops ByteDance, AppsFlyer and Firebase analytics, background location uploads and crash reporting.",
+                    Settings.DISABLE_ANALYTICS
+            ));
+        }
     }
 }
 

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/telemetry/DisableTelemetryPatch.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/telemetry/DisableTelemetryPatch.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2026 hxreborn
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+package app.morphe.extension.tiktok.telemetry;
+
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.tiktok.settings.Settings;
+
+public final class DisableTelemetryPatch {
+    private DisableTelemetryPatch() {}
+
+    public static boolean isTelemetryDisabled() {
+        // Keep analytics enabled if the context isn't initialized yet
+        return Utils.getContext() != null && Settings.DISABLE_ANALYTICS.get();
+    }
+}

--- a/patches-list.json
+++ b/patches-list.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0",
+  "version": "v0.6.0",
   "appNames": {
     "com.zhiliaoapp.musically": "TikTok"
   },
@@ -142,9 +142,12 @@
     },
     {
       "name": "Disable telemetry",
-      "description": "Disables ByteDance AppLog analytics, AppsFlyer attribution tracking, BDLocation background uploads, Firebase Analytics, and crash reporting. (Supports TikTok 43.8.3.)",
+      "description": "Adds a Miscellaneous toggle that disables ByteDance AppLog analytics, AppsFlyer attribution tracking, BDLocation background uploads, Firebase Analytics, and crash reporting. Off by default. (Supports TikTok 43.8.3.)",
       "use": true,
-      "dependencies": [],
+      "dependencies": [
+        "BytecodePatch",
+        "BytecodePatch"
+      ],
       "compatiblePackages": {
         "com.zhiliaoapp.musically": [
           "43.8.3"

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/telemetry/DisableTelemetryPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/telemetry/DisableTelemetryPatch.kt
@@ -4,25 +4,82 @@
  */
 package app.morphe.patches.tiktok.misc.telemetry
 
-import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.shared.compat.AppCompatibilities
+import app.morphe.patches.tiktok.misc.extension.sharedExtensionPatch
+import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint
+import app.morphe.patches.tiktok.misc.settings.settingsPatch
+import app.morphe.util.cloneMutable
+import app.morphe.util.cloneMutableAndPreserveParameters
 import app.morphe.util.findMutableMethodOf
 import app.morphe.util.getReference
-import app.morphe.util.returnEarly
+import app.morphe.util.numberOfParameterRegisters
+import app.morphe.util.numberOfParameterRegistersLogical
+import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+private const val EXTENSION_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/telemetry/DisableTelemetryPatch;"
+private const val BD_LOCATION_CONFIG_DESCRIPTOR = "Lcom/bytedance/bdlocation/client/BDLocationConfig;"
+
+context(BytecodePatchContext)
+private fun Method.returnEarlyIfTelemetryDisabled(disabledInstructions: (register: Int) -> String) {
+    val scratchRegister = implementation?.registerCount
+        ?: throw PatchException("Cannot guard a method without an implementation: $this")
+    val guardIndex = numberOfParameterRegistersLogical
+
+    val guardedMethod = if (numberOfParameterRegisters == 0) {
+        cloneMutable(additionalRegisters = 1).also { clonedMethod ->
+            mutableClassDefBy(definingClass).methods.apply {
+                remove(this@returnEarlyIfTelemetryDisabled)
+                add(clonedMethod)
+            }
+        }
+    } else {
+        // Keep the original parameters intact when the guard uses a shifted parameter register
+        cloneMutableAndPreserveParameters()
+    }
+
+    guardedMethod.addInstructionsWithLabels(
+        guardIndex,
+        """
+            invoke-static {}, $EXTENSION_CLASS_DESCRIPTOR->isTelemetryDisabled()Z
+            move-result v$scratchRegister
+            if-eqz v$scratchRegister, :morphe_telemetry_enabled
+            ${disabledInstructions(scratchRegister)}
+        """,
+        ExternalLabel(
+            "morphe_telemetry_enabled",
+            guardedMethod.getInstruction(guardIndex),
+        ),
+    )
+}
 
 @Suppress("unused")
 val disableTelemetryPatch = bytecodePatch(
     name = "Disable telemetry",
-    description = "Disables ByteDance AppLog analytics, AppsFlyer attribution tracking, " +
-        "BDLocation background uploads, Firebase Analytics, and crash reporting. " +
-        "(Supports TikTok 43.8.3.)",
+    description = "Adds a Miscellaneous toggle that disables ByteDance AppLog analytics, AppsFlyer attribution " +
+        "tracking, BDLocation background uploads, Firebase Analytics, and crash reporting. " +
+        "Off by default. (Supports TikTok 43.8.3.)",
 ) {
+    dependsOn(
+        sharedExtensionPatch,
+        settingsPatch,
+    )
+
     compatibleWith(*AppCompatibilities.tiktok4383())
 
     execute {
+        SettingsStatusLoadFingerprint.method.addInstruction(
+            0,
+            "invoke-static {}, Lapp/morphe/extension/tiktok/settings/SettingsStatus;->enableDisableTelemetry()V",
+        )
+
         listOf(
             AppLogInitFingerprint,
             AppLogStartFingerprint,
@@ -35,10 +92,10 @@ val disableTelemetryPatch = bytecodePatch(
             AppLogFlushAsyncFingerprint,
             AppLogOnActivityPauseFingerprint,
         ).forEach { fingerprint ->
-            fingerprint.method.returnEarly()
+            fingerprint.method.returnEarlyIfTelemetryDisabled { "return-void" }
         }
 
-        InitAppsFlyerRunFingerprint.method.returnEarly()
+        InitAppsFlyerRunFingerprint.method.returnEarlyIfTelemetryDisabled { "return-void" }
 
         // AppsFlyer declares its API methods as abstract, so patch the singleton's concrete overrides.
         val appsFlyerImplementationClass = AppsFlyerGetInstanceFingerprint.method.implementation
@@ -52,34 +109,39 @@ val disableTelemetryPatch = bytecodePatch(
             AppsFlyerLogEventFingerprint,
             AppsFlyerLogLocationFingerprint,
         ).forEach { fingerprint ->
-            appsFlyerClass.findMutableMethodOf(fingerprint.originalMethod).returnEarly()
+            appsFlyerClass.findMutableMethodOf(fingerprint.originalMethod)
+                .returnEarlyIfTelemetryDisabled { "return-void" }
         }
 
         // This SDK is not bundled in the 43.8.3 global APK, but some package variants may include it.
-        BDLocationSetUploadFingerprint.methodOrNull?.addInstructions(
-            0,
+        BDLocationSetUploadFingerprint.methodOrNull?.returnEarlyIfTelemetryDisabled { register ->
             """
-                const/4 p0, 0x0
-                sput-boolean p0, Lcom/bytedance/bdlocation/client/BDLocationConfig;->sIsUpload:Z
-                sput-boolean p0, Lcom/bytedance/bdlocation/client/BDLocationConfig;->sIsUploadGPS:Z
-                sput-boolean p0, Lcom/bytedance/bdlocation/client/BDLocationConfig;->sIsUploadLocation:Z
-                sput-boolean p0, Lcom/bytedance/bdlocation/client/BDLocationConfig;->sIsUploadBaseSite:Z
-                sput-boolean p0, Lcom/bytedance/bdlocation/client/BDLocationConfig;->sIsUploadWIFI:Z
-                sput-boolean p0, Lcom/bytedance/bdlocation/client/BDLocationConfig;->sUploadMccAndSystemRegionInfo:Z
+                const/16 v$register, 0x0
+                sput-boolean v$register, $BD_LOCATION_CONFIG_DESCRIPTOR->sIsUpload:Z
+                sput-boolean v$register, $BD_LOCATION_CONFIG_DESCRIPTOR->sIsUploadGPS:Z
+                sput-boolean v$register, $BD_LOCATION_CONFIG_DESCRIPTOR->sIsUploadLocation:Z
+                sput-boolean v$register, $BD_LOCATION_CONFIG_DESCRIPTOR->sIsUploadBaseSite:Z
+                sput-boolean v$register, $BD_LOCATION_CONFIG_DESCRIPTOR->sIsUploadWIFI:Z
+                sput-boolean v$register, $BD_LOCATION_CONFIG_DESCRIPTOR->sUploadMccAndSystemRegionInfo:Z
                 return-void
-            """,
-        )
+            """
+        }
 
         listOf(
             BDLocationIsUploadFingerprint,
             BDLocationIsUploadGPSFingerprint,
             BDLocationIsUploadLocationFingerprint,
         ).forEach { fingerprint ->
-            fingerprint.methodOrNull?.returnEarly(false)
+            fingerprint.methodOrNull?.returnEarlyIfTelemetryDisabled { register ->
+                """
+                    const/16 v$register, 0x0
+                    return v$register
+                """
+            }
         }
 
-        FirebaseSetCurrentScreenFingerprint.method.returnEarly()
-        MonitorCrashReportCustomErrFingerprint.method.returnEarly()
-        MonitorCrashReportEventFingerprint.method.returnEarly()
+        FirebaseSetCurrentScreenFingerprint.method.returnEarlyIfTelemetryDisabled { "return-void" }
+        MonitorCrashReportCustomErrFingerprint.method.returnEarlyIfTelemetryDisabled { "return-void" }
+        MonitorCrashReportEventFingerprint.method.returnEarlyIfTelemetryDisabled { "return-void" }
     }
 }


### PR DESCRIPTION
Off-by-default "Disable analytics" toggle under Miscellaneous. When on, it stubs the same ByteDance AppLog, AppsFlyer, BDLocation, Firebase, and crash-reporting methods the ReVanced patch targets, behind a runtime check so stock behavior stays unchanged otherwise.

Ported from ReVanced 473a7063a