### PR TITLE
fix: re-anchor Downloads and Navigation fingerprints across TikTok builds

### DIFF
--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/interaction/downloads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/interaction/downloads/Fingerprints.kt
@@ -86,44 +86,33 @@ internal object StickerPreviewBinderFingerprint : Fingerprint(
         "Ljava/lang/String;",
         "Ljava/util/Map;",
     ),
-    custom = { method, classDef ->
-        if (!classDef.endsWith("/05No;") || method.name != "LIZ") {
+    custom = { method, _ ->
+        val instructions = method.implementation?.instructions
+        if (instructions == null) {
             false
         } else {
-            val instructions = method.implementation?.instructions
-            if (instructions == null) {
-                false
-            } else {
-                var readsUrlModel = false
-                var bindsActionButton = false
-                var loadsStickerImage = false
+            var readsUrlModel = false
+            var readsStickerImageView = false
+            var queriesStickerApi = false
 
-                instructions.forEach { instruction ->
-                    instruction.getReference<FieldReference>()?.let { field ->
-                        if (field.type == "Lcom/ss/android/ugc/aweme/base/model/UrlModel;") {
-                            readsUrlModel = true
-                        }
-                    }
-
-                    instruction.getReference<MethodReference>()?.let { methodReference ->
-                        if (methodReference.definingClass == "LX/05No;" &&
-                            methodReference.name == "LIZIZ" &&
-                            methodReference.parameterTypes == listOf("LX/0Daq;", "LX/05Nn;") &&
-                            methodReference.returnType == "V"
-                        ) {
-                            bindsActionButton = true
-                        }
-
-                        if (methodReference.definingClass == "LX/0zaJ;" &&
-                            methodReference.name == "LIZJ"
-                        ) {
-                            loadsStickerImage = true
-                        }
+            instructions.forEach { instruction ->
+                instruction.getReference<FieldReference>()?.let { field ->
+                    when (field.type) {
+                        "Lcom/ss/android/ugc/aweme/base/model/UrlModel;" -> readsUrlModel = true
+                        "Lcom/bytedance/lighten/loader/SmartImageView;" -> readsStickerImageView = true
                     }
                 }
 
-                readsUrlModel && bindsActionButton && loadsStickerImage
+                instruction.getReference<MethodReference>()?.let { methodReference ->
+                    if (methodReference.definingClass ==
+                        "Lcom/ss/android/ugc/aweme/im/sticker/api/IMStickerApi;"
+                    ) {
+                        queriesStickerApi = true
+                    }
+                }
             }
+
+            readsUrlModel && readsStickerImageView && queriesStickerApi
         }
     },
 )

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/navigation/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/misc/navigation/Fingerprints.kt
@@ -10,8 +10,7 @@ internal object HomeTabAbilityListFingerprint : Fingerprint(
 )
 
 internal object BottomTabBuildListFingerprint : Fingerprint(
-    definingClass = "/0tBq;",
-    name = "LJJL",
     returnType = "V",
     parameters = listOf("Ljava/util/List;"),
+    strings = listOf("HOME", "PUBLISH", "FRIENDS_TAB", "SHOP_MALL", "NOTIFICATION"),
 )


### PR DESCRIPTION
re-anchor downloads + nav fingerprints to survive R8 rebuilds, no-op on the pinned build