### PR TITLE
chore: Merge branch `dev` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Everything from [icysymmetra's upstream](https://github.com/icysymmetra/tiktok-p
 \*TikTok decides which accounts count as institutions. Major news outlets usually carry that tag and
 stay in your feed, but some do not and get hidden like any other verified account.
 
-Last synced with upstream at [`085145d`](https://github.com/icysymmetra/tiktok-patches-for-morphe/commit/085145d). Release numbers are this fork's own and do not track upstream's.
+Last synced with upstream at [`ce30cfd`](https://github.com/icysymmetra/tiktok-patches-for-morphe/commit/ce30cfd). Release numbers are this fork's own and do not track upstream's.
 
 <br>
 


### PR DESCRIPTION
Bumps the last-synced upstream pointer in the README.