### PR TITLE
ci: fix empty stable release notes after a prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           tag='${{ steps.release.outputs.new_release_git_tag }}'
-          prev=$(git describe --tags --abbrev=0 "$tag^")
-          npx git-cliff --config .github/cliff.toml "$prev..$tag" --strip all > /tmp/notes.md
+          case "$tag" in
+            *-*)
+              # Prerelease: compare against the previous tag on any channel.
+              prev=$(git describe --tags --abbrev=0 "$tag^")
+              npx git-cliff --config .github/cliff.toml "$prev..$tag" --strip all > /tmp/notes.md
+              ;;
+            *)
+              # Stable: skip the prereleases this cut already contains, or the range is empty.
+              prev=$(git describe --tags --abbrev=0 --exclude='*-*' "$tag^")
+              npx git-cliff --config .github/cliff.toml "$prev..$tag" --ignore-tags '.*-.*' --strip all > /tmp/notes.md
+              ;;
+          esac
+          if ! grep -q '^- ' /tmp/notes.md; then
+            echo "::error::Release notes for $tag are empty (range $prev..$tag)."
+            exit 1
+          fi
           gh release edit "$tag" --notes-file /tmp/notes.md
 
       - name: Attest


### PR DESCRIPTION
git describe picked the dev tag so the stable range was empty. Fails the run now if notes come out empty.