### PR TITLE
fix(TikTok - Feed filter): unlock scrolling past countdown-locked short-drama ads

### DIFF
--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/DramaBlockingAdFilter.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/DramaBlockingAdFilter.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2026 hxreborn
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+package app.morphe.extension.tiktok.feedfilter;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.tiktok.settings.Settings;
+
+@SuppressWarnings("unused")
+public final class DramaBlockingAdFilter {
+    private DramaBlockingAdFilter() {}
+
+    public static boolean shouldBlock(boolean isBlockingAd) {
+        if (isBlockingAd && Settings.REMOVE_ADS.get()) {
+            Logger.printInfo(() -> "[Morphe TikTok FeedFilter] unblocked countdown-locked drama ad");
+            return false;
+        }
+        return isBlockingAd;
+    }
+}

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt
@@ -15,6 +15,7 @@ import app.morphe.patches.tiktok.misc.extension.sharedExtensionPatch
 import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint
 import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint.method
 import app.morphe.util.addInstructionsAtControlFlowLabel
+import app.morphe.util.indexOfFirstInstructionOrThrow
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
@@ -24,11 +25,12 @@ private const val TAKO_AI_FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tikto
 private const val PLAYLIST_BAR_FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/PlaylistBarFilter;"
 private const val EVENT_BADGE_FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/EventBadgeFilter;"
 private const val FRIEND_RECOMMENDATION_FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/FriendRecommendationFilter;"
+private const val DRAMA_BLOCKING_AD_FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/DramaBlockingAdFilter;"
 
 @Suppress("unused")
 val feedFilterPatch = bytecodePatch(
     name = "Feed filter",
-    description = "Hides feed ads, TikTok Shop items, livestreams, stories, photo posts, the playlist bar, the floating event badge, AI-generated posts, paid partnership and promotional content, the account, bulletin-board and other inserted cards, posts from verified accounts, and videos outside configured view or like ranges.",
+    description = "Hides feed ads, TikTok Shop items, livestreams, stories, photo posts, the playlist bar, the floating event badge, AI-generated posts, paid partnership and promotional content, the account, bulletin-board and other inserted cards, posts from verified accounts, videos outside configured view or like ranges, and the countdown lock on short-drama ads.",
     default = true,
 ) {
     dependsOn(
@@ -192,6 +194,21 @@ val feedFilterPatch = bytecodePatch(
                 nop
             """,
         )
+
+        DramaBlockingAdFingerprint.methodOrNull?.apply {
+            val returnIndex = indexOfFirstInstructionOrThrow {
+                opcode == Opcode.RETURN
+            }
+            val register = (getInstruction(returnIndex) as OneRegisterInstruction).registerA
+
+            addInstructions(
+                returnIndex,
+                """
+                    invoke-static {v$register}, $DRAMA_BLOCKING_AD_FILTER_CLASS_DESCRIPTOR->shouldBlock(Z)Z
+                    move-result v$register
+                """,
+            )
+        }
 
         // Skip attaching the promotional event badge to the feed
         SpecActTouchpointAttachFingerprint.methodOrNull?.addInstructions(

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/Fingerprints.kt
@@ -49,6 +49,12 @@ internal object PlaylistBottomBarAvailableFingerprint : Fingerprint(
     parameters = listOf("Lcom/ss/android/ugc/aweme/feed/model/VideoItemParams;"),
 )
 
+internal object DramaBlockingAdFingerprint : Fingerprint(
+    definingClass = "Lcom/ss/android/ugc/aweme/impl/DramaBlockingAdServiceImpl;",
+    returnType = "Z",
+    parameters = listOf("Lcom/ss/android/ugc/aweme/feed/model/Aweme;"),
+)
+
 internal object SpecActTouchpointAttachFingerprint : Fingerprint(
     definingClass = "/specact/SpecActServiceImpl;",
     returnType = "V",


### PR DESCRIPTION
Tested on TikTok 46.2.3 (Pixel 4 XL).