### PR TITLE
ci: keep upstream dev-to-main merge commits out of the changelog

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -61,6 +61,8 @@ commit_preprocessors = [
 ]
 # Mirrors semantic-release's angular preset: only feat, fix, perf and revert reach the notes.
 commit_parsers = [
+  # Upstream types its dev-to-main merges as fix, which would otherwise land in our notes
+  { message = "^(feat|fix|perf|revert)(\\(.*\\))?!?: [Mm]erge ", skip = true },
   { message = "^feat", group = "<!-- 00 -->Features" },
   { message = "^fix", group = "<!-- 01 -->Bug Fixes" },
   { message = "^perf", group = "<!-- 02 -->Performance Improvements" },

--- a/.releaserc
+++ b/.releaserc
@@ -37,10 +37,26 @@
             "type": "release",
             "release": "patch"
           }
-        ]
+        ],
+        "parserOpts": {
+          "mergePattern": "^(?:fix|feat|perf|revert)(?:\\(.*\\))?!?: [Mm]erge (.*)$",
+          "mergeCorrespondence": [
+            "upstreamMerge"
+          ]
+        }
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "parserOpts": {
+          "mergePattern": "^(?:fix|feat|perf|revert)(?:\\(.*\\))?!?: [Mm]erge (.*)$",
+          "mergeCorrespondence": [
+            "upstreamMerge"
+          ]
+        }
+      }
+    ],
     [
       "@MorpheApp/changelog",
       {


### PR DESCRIPTION
Verified against v0.11.4..HEAD: both bogus entries drop, all real commits keep their type.