### PR TITLE
fix(TikTok - Feed filter): hide real-time inserted cards and stop their Lynx view preloading

### DIFF
--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/CardInsertFilter.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/CardInsertFilter.java
@@ -4,16 +4,15 @@
  */
 package app.morphe.extension.tiktok.feedfilter;
 
-import app.morphe.extension.shared.Logger;
 import app.morphe.extension.tiktok.settings.Settings;
 import com.ss.android.ugc.aweme.feed.model.Aweme;
 
 public class CardInsertFilter implements IFilter {
-    private static final int AWEME_TYPE_INSERT_CARD = 105;
+    static final int AWEME_TYPE_INSERT_CARD = 105;
 
     @Override
     public boolean getEnabled() {
-        return Settings.HIDE_FRIEND_RECOMMENDATIONS.get();
+        return shouldHide();
     }
 
     @Override
@@ -21,9 +20,7 @@ public class CardInsertFilter implements IFilter {
         return item.getAwemeType() == AWEME_TYPE_INSERT_CARD;
     }
 
-    public static boolean shouldBlockMusic() {
-        boolean block = Settings.HIDE_FRIEND_RECOMMENDATIONS.get();
-        Logger.printInfo(() -> "[Morphe TikTok FeedFilter] bulletin music requested: block=" + block);
-        return block;
+    public static boolean shouldHide() {
+        return Settings.HIDE_FRIEND_RECOMMENDATIONS.get();
     }
 }

--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/FeedItemsFilter.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/FeedItemsFilter.java
@@ -123,7 +123,9 @@ public final class FeedItemsFilter {
         List items
     ) {
         if (items == null || items.isEmpty()) return items;
-        if (!Settings.FILTER_CACHED_OFFLINE_VIDEOS.get()) return items;
+        boolean hideCards = CardInsertFilter.shouldHide();
+        boolean filterCache = Settings.FILTER_CACHED_OFFLINE_VIDEOS.get();
+        if (!hideCards && !filterCache) return items;
         if (panel == null || !"homepage_hot".equals(panel.getEventType())) return items;
 
         List<IFilter> activeContentFilters = getActiveFilters(CONTENT_FILTERS);
@@ -143,14 +145,14 @@ public final class FeedItemsFilter {
             }
 
             Aweme item = (Aweme) container;
-            int cacheSourceType = AwemeBizExtKt.getCacheSourceType(item);
-            if (!cacheInsertion && !isKnownFeedCacheSource(cacheSourceType)) {
-                if (kept != null) kept.add(container);
-                continue;
+            String reason = null;
+            if (hideCards && item.getAwemeType() == CardInsertFilter.AWEME_TYPE_INSERT_CARD) {
+                reason = CardInsertFilter.class.getSimpleName();
+            } else if (filterCache
+                && (cacheInsertion || isKnownFeedCacheSource(AwemeBizExtKt.getCacheSourceType(item)))) {
+                reason = getFilterReason(activeContentFilters, item);
+                if (reason == null) reason = getFilterReason(activeRangeFilters, item);
             }
-
-            String reason = getFilterReason(activeContentFilters, item);
-            if (reason == null) reason = getFilterReason(activeRangeFilters, item);
             if (reason == null) {
                 if (kept != null) kept.add(container);
                 continue;

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt
@@ -15,7 +15,6 @@ import app.morphe.patches.tiktok.misc.extension.sharedExtensionPatch
 import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint
 import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint.method
 import app.morphe.util.addInstructionsAtControlFlowLabel
-import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
@@ -197,31 +196,19 @@ val feedFilterPatch = bytecodePatch(
             """,
         )
 
-        // Bulletin music outlives the feed player and its mute
-        BulletinMusicPlayFingerprint.methodOrNull?.let { method ->
-            val musicIndex = method.implementation!!.instructions.indexOfFirst {
-                it.opcode == Opcode.IGET_OBJECT &&
-                    it.getReference<FieldReference>()?.type == "Lcom/ss/android/ugc/aweme/music/model/Music;"
-            }
-            check(musicIndex >= 0) { "Could not find the bulletin music field read" }
-
-            val musicRegister = (method.getInstruction(musicIndex) as OneRegisterInstruction).registerA
-            val freeRegister = if (musicRegister == 0) 1 else 0
-
-            method.addInstructionsWithLabels(
-                musicIndex + 1,
-                """
-                    invoke-static {}, $CARD_INSERT_FILTER_CLASS_DESCRIPTOR->shouldBlockMusic()Z
-                    move-result v$freeRegister
-                    if-eqz v$freeRegister, :morphe_play_bulletin_music
-                    const/4 v$musicRegister, 0x0
-                """,
-                ExternalLabel(
-                    "morphe_play_bulletin_music",
-                    method.getInstruction(musicIndex + 1),
-                ),
-            )
-        }
+        // Card Lynx views preload before any list filter runs
+        FeedLynxCardLoadFingerprint.method.addInstructions(
+            0,
+            """
+                invoke-static {}, $CARD_INSERT_FILTER_CLASS_DESCRIPTOR->shouldHide()Z
+                move-result v0
+                if-eqz v0, :morphe_load_feed_card
+                const/4 v0, 0x0
+                return v0
+                :morphe_load_feed_card
+                nop
+            """,
+        )
 
         DramaBlockingAdFingerprint.methodOrNull?.apply {
             val returnIndex = indexOfFirstInstructionOrThrow {

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/Fingerprints.kt
@@ -139,12 +139,15 @@ internal object RecUserCardInsertFingerprint : Fingerprint(
     strings = listOf("friend_recommend_card"),
 )
 
-internal object BulletinMusicPlayFingerprint : Fingerprint(
-    returnType = "Lkotlin/Pair;",
-    custom = { method, _ ->
-        method.implementation?.instructions?.any {
-            it.getReference<MethodReference>()?.definingClass ==
-                "Lcom/ss/android/ugc/aweme/inbox/bulletin/music/LifecycleMusicPlayer;"
-        } == true
-    },
+internal object FeedLynxCardLoadFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
+    returnType = "Z",
+    parameters = listOf(
+        "Landroid/content/Context;",
+        "Ljava/lang/String;",
+        "Lcom/ss/android/ugc/aweme/feed/model/Aweme;",
+        "Ljava/lang/String;",
+        "L",
+    ),
+    strings = listOf("feedDynamicComponentLoadSuccess"),
 )


### PR DESCRIPTION
Tested on TikTok 46.2.3: bundle applies clean, launches clean, both hooks confirmed in the patched dex.