### PR TITLE
fix(TikTok - Feed filter): silence inserted card music that kept playing after the card left

### DIFF
--- a/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/CardInsertFilter.java
+++ b/extensions/tiktok/src/main/java/app/morphe/extension/tiktok/feedfilter/CardInsertFilter.java
@@ -4,6 +4,7 @@
  */
 package app.morphe.extension.tiktok.feedfilter;
 
+import app.morphe.extension.shared.Logger;
 import app.morphe.extension.tiktok.settings.Settings;
 import com.ss.android.ugc.aweme.feed.model.Aweme;
 
@@ -22,5 +23,16 @@ public class CardInsertFilter implements IFilter {
 
     public static boolean shouldHide() {
         return Settings.HIDE_FRIEND_RECOMMENDATIONS.get();
+    }
+
+    // x-audio-tt chokepoint for a card's audio that outlives its view
+    public static boolean blockLynxAudio(String src) {
+        boolean block = shouldHide();
+        Logger.printInfo(() -> "[Morphe TikTok FeedFilter] lynx audio src=" + src + " block=" + block);
+        return block;
+    }
+
+    public static boolean blockLynxAudio() {
+        return shouldHide();
     }
 }

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/FeedFilterPatch.kt
@@ -15,10 +15,13 @@ import app.morphe.patches.tiktok.misc.extension.sharedExtensionPatch
 import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint
 import app.morphe.patches.tiktok.misc.settings.SettingsStatusLoadFingerprint.method
 import app.morphe.util.addInstructionsAtControlFlowLabel
+import app.morphe.util.findFreeRegister
+import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstructionOrThrow
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 private const val EXTENSION_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/FeedItemsFilter;"
 private const val TAKO_AI_FILTER_CLASS_DESCRIPTOR = "Lapp/morphe/extension/tiktok/feedfilter/TakoAiFilter;"
@@ -196,19 +199,88 @@ val feedFilterPatch = bytecodePatch(
             """,
         )
 
-        // Card Lynx views preload before any list filter runs
-        FeedLynxCardLoadFingerprint.method.addInstructions(
+        // Release the card Spark view before load so no Lynx audio starts
+        FeedLynxCardBuildFingerprint.method.apply {
+            val viewType = returnType
+            val factoryIndex = indexOfFirstInstructionOrThrow {
+                opcode == Opcode.INVOKE_VIRTUAL &&
+                    getReference<MethodReference>()?.returnType == viewType
+            }
+            val viewRegister = (getInstruction(factoryIndex + 1) as OneRegisterInstruction).registerA
+            val insertIndex = factoryIndex + 2
+            val freeRegister = findFreeRegister(insertIndex, viewRegister)
+
+            addInstructionsWithLabels(
+                insertIndex,
+                """
+                    invoke-static {}, $CARD_INSERT_FILTER_CLASS_DESCRIPTOR->shouldHide()Z
+                    move-result v$freeRegister
+                    if-eqz v$freeRegister, :morphe_build_feed_card
+                    invoke-virtual {v$viewRegister}, $viewType->release()V
+                    return-object v$viewRegister
+                """,
+                ExternalLabel("morphe_build_feed_card", getInstruction(insertIndex)),
+            )
+        }
+
+        // Block a card's Lynx audio at the x-audio-tt chokepoint
+        LynxAudioSetSrcFingerprint.methodOrNull?.addInstructions(
             0,
             """
-                invoke-static {}, $CARD_INSERT_FILTER_CLASS_DESCRIPTOR->shouldHide()Z
+                invoke-static {p1}, $CARD_INSERT_FILTER_CLASS_DESCRIPTOR->blockLynxAudio(Ljava/lang/String;)Z
                 move-result v0
-                if-eqz v0, :morphe_load_feed_card
-                const/4 v0, 0x0
-                return v0
-                :morphe_load_feed_card
+                if-eqz v0, :morphe_allow_lynx_src
+                return-void
+                :morphe_allow_lynx_src
                 nop
             """,
         )
+
+        LynxAudioPlayFingerprint.methodOrNull?.addInstructions(
+            0,
+            """
+                invoke-static {}, $CARD_INSERT_FILTER_CLASS_DESCRIPTOR->blockLynxAudio()Z
+                move-result v0
+                if-eqz v0, :morphe_allow_lynx_play
+                return-void
+                :morphe_allow_lynx_play
+                nop
+            """,
+        )
+
+        LynxAudioPrepareFingerprint.methodOrNull?.addInstructions(
+            0,
+            """
+                invoke-static {}, $CARD_INSERT_FILTER_CLASS_DESCRIPTOR->blockLynxAudio()Z
+                move-result v0
+                if-eqz v0, :morphe_allow_lynx_prepare
+                return-void
+                :morphe_allow_lynx_prepare
+                nop
+            """,
+        )
+
+        // Never build the bulletin card's persistent native player
+        BulletinMusicPlayFingerprint.methodOrNull?.let { method ->
+            val musicIndex = method.implementation!!.instructions.indexOfFirst {
+                it.opcode == Opcode.IGET_OBJECT &&
+                    it.getReference<FieldReference>()?.type == "Lcom/ss/android/ugc/aweme/music/model/Music;"
+            }
+            if (musicIndex >= 0) {
+                val musicRegister = (method.getInstruction(musicIndex) as OneRegisterInstruction).registerA
+                val freeRegister = method.findFreeRegister(musicIndex + 1, musicRegister)
+                method.addInstructionsWithLabels(
+                    musicIndex + 1,
+                    """
+                        invoke-static {}, $CARD_INSERT_FILTER_CLASS_DESCRIPTOR->shouldHide()Z
+                        move-result v$freeRegister
+                        if-eqz v$freeRegister, :morphe_play_bulletin_music
+                        const/4 v$musicRegister, 0x0
+                    """,
+                    ExternalLabel("morphe_play_bulletin_music", method.getInstruction(musicIndex + 1)),
+                )
+            }
+        }
 
         DramaBlockingAdFingerprint.methodOrNull?.apply {
             val returnIndex = indexOfFirstInstructionOrThrow {

--- a/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/morphe/patches/tiktok/feedfilter/Fingerprints.kt
@@ -139,15 +139,38 @@ internal object RecUserCardInsertFingerprint : Fingerprint(
     strings = listOf("friend_recommend_card"),
 )
 
-internal object FeedLynxCardLoadFingerprint : Fingerprint(
+internal object FeedLynxCardBuildFingerprint : Fingerprint(
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC),
-    returnType = "Z",
-    parameters = listOf(
-        "Landroid/content/Context;",
-        "Ljava/lang/String;",
-        "Lcom/ss/android/ugc/aweme/feed/model/Aweme;",
-        "Ljava/lang/String;",
-        "L",
-    ),
-    strings = listOf("feedDynamicComponentLoadSuccess"),
+    strings = listOf("lynx_card_init_time"),
+)
+
+internal object BulletinMusicPlayFingerprint : Fingerprint(
+    returnType = "Lkotlin/Pair;",
+    custom = { method, _ ->
+        method.implementation?.instructions?.any {
+            it.getReference<MethodReference>()?.definingClass ==
+                "Lcom/ss/android/ugc/aweme/inbox/bulletin/music/LifecycleMusicPlayer;"
+        } == true
+    },
+)
+
+internal object LynxAudioSetSrcFingerprint : Fingerprint(
+    definingClass = "Lcom/bytedance/ies/xelement/audiott/LynxAudioTTView;",
+    name = "setSrc",
+    returnType = "V",
+    parameters = listOf("Ljava/lang/String;"),
+)
+
+internal object LynxAudioPlayFingerprint : Fingerprint(
+    definingClass = "Lcom/bytedance/ies/xelement/audiott/LynxAudioTTView;",
+    name = "play",
+    returnType = "V",
+    parameters = listOf("Lcom/lynx/react/bridge/Callback;"),
+)
+
+internal object LynxAudioPrepareFingerprint : Fingerprint(
+    definingClass = "Lcom/bytedance/ies/xelement/audiott/LynxAudioTTView;",
+    name = "prepare",
+    returnType = "V",
+    parameters = listOf("Lcom/lynx/react/bridge/Callback;"),
 )


### PR DESCRIPTION
Blocks a card audio at the chokepoints it must pass: the Lynx x-audio-tt player (play/prepare/setSrc) and the native bulletin player, plus the card-view release and the feed-item filter. setSrc logs the audio URL to the in-app buffer so the next occurrence identifies the source. Tested on TikTok 46.2.3: bundle applies clean, all four gates confirmed in the patched dex, installs and launches. Live card is server-gated so on-device silence is pending a natural card.